### PR TITLE
feat: [CHA-2958] structured error handling + WaitForTaskAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Error Handling (CHA-2958)
+
+Structured exception hierarchy replaces the raw-body-only `GetStreamApiException`. Backend `APIError` envelopes are now parsed into typed fields, transport failures are wrapped, 429s expose a parsed `Retry-After`, and `BaseClient.WaitForTaskAsync` lets callers surface async task failures.
+
+**New exception types (`GetStream` namespace):**
+
+- `GetStreamException`: abstract base.
+- `GetStreamApiException`: 4xx/5xx with parsed envelope. Fields: `StatusCode`, `Code`, `Message`, `ExceptionFields` (`IReadOnlyDictionary<string,string>`), `Unrecoverable`, `RawResponseBody`, `MoreInfo`, `Details`.
+- `GetStreamRateLimitException : GetStreamApiException`: thrown on HTTP 429. Adds `RetryAfter` (`TimeSpan?`) parsed from the `Retry-After` header (integer seconds and HTTP-date, RFC 7231 §7.1.3).
+- `GetStreamTransportException`: wraps network-layer failures (connection reset, timeout, DNS, TLS). Adds `ErrorType` (`connection_reset` | `timeout` | `dns_failure` | `tls_handshake_failed` | `unknown`). The underlying exception is preserved as `InnerException`.
+- `GetStreamTaskException`: thrown by `WaitForTaskAsync` when an async task completes with `status = "failed"`. Fields: `TaskId`, `ErrorType`, `Description`, `StackTrace`, `Version`.
+
+**Removed (dead code):**
+
+- `GetStreamAuthenticationException`
+- `GetStreamValidationException`
+- `GetStreamFeedException`
+
+None of these were ever thrown by the SDK and none were referenced in customer documentation. The audit (2026-05-28) found zero throw sites in `src/` and zero matches in `/docs/data/docs/`. Migration for users who wrote defensive catches against any of them:
+
+```csharp
+// before
+catch (GetStreamAuthenticationException ex) { ... }
+
+// after
+catch (GetStreamApiException ex) when (ex.StatusCode is 401 or 403) { ... }
+```
+
+**Behavior changes (no breaking API changes outside the deletions above):**
+
+- HTTP responses with 4xx/5xx are deserialized into the existing `APIError` model and the typed fields flow through to `GetStreamApiException`. If the body cannot be parsed as `APIError`, the SDK still throws `GetStreamApiException` with `Code = 0`, `Message = "failed to parse error response"`, and `RawResponseBody` set to the original payload (spec §6.3).
+- Transport-layer failures (`HttpRequestException`, `TaskCanceledException` from the framework `HttpClient.Timeout`, `SocketException`, `TimeoutException`, `IOException`) at the request boundary are caught and re-thrown as `GetStreamTransportException`. The original exception is preserved as `InnerException`. Caller-supplied `CancellationToken` cancellation propagates natively (it is not a transport error).
+- `BaseClient.WaitForTaskAsync(taskId, pollInterval?, timeout?, cancellationToken?)` polls `/api/v2/tasks/{id}` until terminal state. Defaults: `pollInterval = 1s`, `timeout = 60s`. Returns the `GetTaskResponse` on completion, throws `GetStreamTaskException` on failure, throws `GetStreamTransportException` with `ErrorType = "timeout"` on timeout.
+
+The unit suite for the above is in `tests/ErrorHandlingTests.cs` and runs without credentials.
+
 ### Connection Pooling (CHA-2956)
 
 New `StreamOptions` class for explicit HTTP connection-pool tuning. Five knobs:

--- a/FEEDS_V2_TO_V3_MIGRATION.md
+++ b/FEEDS_V2_TO_V3_MIGRATION.md
@@ -21,7 +21,7 @@ var activity = response.Data.Activity;  // Access via .Data property
 
 ### 2. Exception Types
 **V2:** `StreamException`
-**V3:** `GetStreamApiException` (with `StatusCode` and `ResponseBody` properties)
+**V3:** `GetStreamApiException` with `StatusCode`, `Code`, `Message`, `ExceptionFields`, `Unrecoverable`, `RawResponseBody`, `MoreInfo`, `Details`. `GetStreamRateLimitException` is a `GetStreamApiException` subclass thrown on HTTP 429 and adds `RetryAfter`. Transport failures (connection reset, timeout, DNS, TLS) become `GetStreamTransportException`; failed async tasks surface as `GetStreamTaskException` from `BaseClient.WaitForTaskAsync`. The pre-CHA-2958 `ResponseBody` property is still available as an obsolete alias for `RawResponseBody`.
 
 ### 3. Activity Model Structure
 **V2:** Uses `Actor`, `Verb`, `Object` pattern

--- a/src/Client.cs
+++ b/src/Client.cs
@@ -478,8 +478,6 @@ namespace GetStream
             return content;
         }
 
-        // --- CHA-2958: error handling ---------------------------------------------------
-
         private static bool IsTransportException(Exception ex, CancellationToken cancellationToken)
         {
             // Caller-supplied cancellation is not a transport error: let it bubble.
@@ -503,7 +501,6 @@ namespace GetStream
 
         private static string ClassifyTransportError(Exception ex)
         {
-            // Walk the inner-exception chain so wrapped transport failures still classify.
             for (var e = ex; e != null; e = e.InnerException)
             {
                 switch (e)
@@ -584,7 +581,7 @@ namespace GetStream
             }
             else
             {
-                // §6.3 internal/unparseable path: HTTP response received but body unusable.
+                // Body cannot be parsed as APIError.
                 message = "failed to parse error response";
                 code = 0;
                 exceptionFields = new Dictionary<string, string>();
@@ -628,7 +625,7 @@ namespace GetStream
             var raw = values.FirstOrDefault();
             if (string.IsNullOrWhiteSpace(raw)) return null;
 
-            // RFC 7231 §7.1.3: integer seconds first, then HTTP-date.
+            // Integer seconds first, then HTTP-date.
             if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds))
             {
                 return TimeSpan.FromSeconds(Math.Max(seconds, 0));
@@ -643,7 +640,6 @@ namespace GetStream
 
         /// <summary>
         /// Poll an async task until it completes, fails, or the timeout elapses.
-        /// CHA-2958 §8.
         /// </summary>
         /// <param name="taskId">Task ID returned by the operation that enqueued it.</param>
         /// <param name="pollInterval">Poll cadence. Defaults to 1 second.</param>

--- a/src/Client.cs
+++ b/src/Client.cs
@@ -3,9 +3,12 @@ using System.Text.Json;
 using System.IdentityModel.Tokens.Jwt;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Extensions.Logging;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
 using GetStream.Models;
 
 namespace GetStream
@@ -146,12 +149,21 @@ namespace GetStream
                 }
             }
 
-            var response = await _httpClient.SendAsync(request, cancellationToken);
-            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            HttpResponseMessage response;
+            string responseContent;
+            try
+            {
+                response = await _httpClient.SendAsync(request, cancellationToken);
+                responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            }
+            catch (Exception ex) when (IsTransportException(ex, cancellationToken))
+            {
+                throw WrapTransportException(ex, cancellationToken);
+            }
 
             if (!response.IsSuccessStatusCode)
             {
-                throw new GetStreamApiException($"HTTP {response.StatusCode}: {responseContent}", (int)response.StatusCode, responseContent);
+                throw BuildApiException(response, responseContent);
             }
 
             // Try to deserialize as the actual response type first
@@ -202,12 +214,21 @@ namespace GetStream
                 }
             }
 
-            var response = await _httpClient.SendAsync(request, cancellationToken);
-            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            HttpResponseMessage response;
+            string responseContent;
+            try
+            {
+                response = await _httpClient.SendAsync(request, cancellationToken);
+                responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            }
+            catch (Exception ex) when (IsTransportException(ex, cancellationToken))
+            {
+                throw WrapTransportException(ex, cancellationToken);
+            }
 
             if (!response.IsSuccessStatusCode)
             {
-                throw new GetStreamApiException($"HTTP {response.StatusCode}: {responseContent}", (int)response.StatusCode, responseContent);
+                throw BuildApiException(response, responseContent);
             }
 
             // Try to deserialize as the actual response type first
@@ -455,6 +476,230 @@ namespace GetStream
             }
 
             return content;
+        }
+
+        // --- CHA-2958: error handling ---------------------------------------------------
+
+        private static bool IsTransportException(Exception ex, CancellationToken cancellationToken)
+        {
+            // Caller-supplied cancellation is not a transport error: let it bubble.
+            if (cancellationToken.IsCancellationRequested && ex is OperationCanceledException)
+            {
+                return false;
+            }
+            return ex is HttpRequestException
+                || ex is TaskCanceledException
+                || ex is TimeoutException
+                || ex is SocketException
+                || ex is IOException;
+        }
+
+        private static GetStreamTransportException WrapTransportException(Exception ex, CancellationToken cancellationToken)
+        {
+            var errorType = ClassifyTransportError(ex);
+            var message = $"transport error ({errorType}): {ex.Message}";
+            return new GetStreamTransportException(message, errorType, ex);
+        }
+
+        private static string ClassifyTransportError(Exception ex)
+        {
+            // Walk the inner-exception chain so wrapped transport failures still classify.
+            for (var e = ex; e != null; e = e.InnerException)
+            {
+                switch (e)
+                {
+                    case TaskCanceledException _:
+                    case TimeoutException _:
+                        return "timeout";
+                    case SocketException sock:
+                        return ClassifySocketError(sock.SocketErrorCode);
+                }
+
+                var typeName = e.GetType().FullName ?? string.Empty;
+                if (typeName.Contains("Authentication", StringComparison.OrdinalIgnoreCase)
+                    || typeName.EndsWith("AuthenticationException", StringComparison.OrdinalIgnoreCase))
+                {
+                    return "tls_handshake_failed";
+                }
+            }
+            return "unknown";
+        }
+
+        private static string ClassifySocketError(SocketError code)
+        {
+            switch (code)
+            {
+                case SocketError.HostNotFound:
+                case SocketError.NoData:
+                case SocketError.TryAgain:
+                    return "dns_failure";
+                case SocketError.TimedOut:
+                    return "timeout";
+                case SocketError.ConnectionReset:
+                case SocketError.ConnectionRefused:
+                case SocketError.ConnectionAborted:
+                case SocketError.NetworkReset:
+                case SocketError.Shutdown:
+                    return "connection_reset";
+                default:
+                    return "unknown";
+            }
+        }
+
+        private GetStreamApiException BuildApiException(HttpResponseMessage response, string responseContent)
+        {
+            var statusCode = (int)response.StatusCode;
+            APIError? parsed = null;
+            Exception? parseError = null;
+
+            if (!string.IsNullOrEmpty(responseContent))
+            {
+                try
+                {
+                    parsed = JsonSerializer.Deserialize<APIError>(responseContent, _jsonOptions);
+                }
+                catch (JsonException jx)
+                {
+                    parseError = jx;
+                }
+            }
+
+            string message;
+            int code;
+            IReadOnlyDictionary<string, string> exceptionFields;
+            bool unrecoverable;
+            string? moreInfo;
+            object? details;
+
+            if (parsed != null && (parsed.Code != 0 || !string.IsNullOrEmpty(parsed.Message)))
+            {
+                message = !string.IsNullOrEmpty(parsed.Message)
+                    ? parsed.Message
+                    : $"HTTP {statusCode}";
+                code = parsed.Code;
+                exceptionFields = parsed.ExceptionFields ?? new Dictionary<string, string>();
+                unrecoverable = parsed.Unrecoverable ?? false;
+                moreInfo = string.IsNullOrEmpty(parsed.MoreInfo) ? null : parsed.MoreInfo;
+                details = parsed.Details;
+            }
+            else
+            {
+                // §6.3 internal/unparseable path: HTTP response received but body unusable.
+                message = "failed to parse error response";
+                code = 0;
+                exceptionFields = new Dictionary<string, string>();
+                unrecoverable = false;
+                moreInfo = null;
+                details = null;
+            }
+
+            if (statusCode == 429)
+            {
+                var retryAfter = ParseRetryAfter(response, DateTimeOffset.UtcNow);
+                return new GetStreamRateLimitException(
+                    message: message,
+                    statusCode: statusCode,
+                    code: code,
+                    exceptionFields: exceptionFields,
+                    unrecoverable: unrecoverable,
+                    rawResponseBody: responseContent ?? string.Empty,
+                    retryAfter: retryAfter,
+                    moreInfo: moreInfo,
+                    details: details,
+                    innerException: parseError);
+            }
+
+            return new GetStreamApiException(
+                message: message,
+                statusCode: statusCode,
+                code: code,
+                exceptionFields: exceptionFields,
+                unrecoverable: unrecoverable,
+                rawResponseBody: responseContent ?? string.Empty,
+                moreInfo: moreInfo,
+                details: details,
+                innerException: parseError);
+        }
+
+        internal static TimeSpan? ParseRetryAfter(HttpResponseMessage response, DateTimeOffset now)
+        {
+            if (response.Headers == null) return null;
+            if (!response.Headers.TryGetValues("Retry-After", out var values)) return null;
+            var raw = values.FirstOrDefault();
+            if (string.IsNullOrWhiteSpace(raw)) return null;
+
+            // RFC 7231 §7.1.3: integer seconds first, then HTTP-date.
+            if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds))
+            {
+                return TimeSpan.FromSeconds(Math.Max(seconds, 0));
+            }
+            if (DateTimeOffset.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var when))
+            {
+                var delta = when - now;
+                return delta < TimeSpan.Zero ? TimeSpan.Zero : delta;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Poll an async task until it completes, fails, or the timeout elapses.
+        /// CHA-2958 §8.
+        /// </summary>
+        /// <param name="taskId">Task ID returned by the operation that enqueued it.</param>
+        /// <param name="pollInterval">Poll cadence. Defaults to 1 second.</param>
+        /// <param name="timeout">Maximum total wait. Defaults to 60 seconds.</param>
+        /// <param name="cancellationToken">Cancels the polling loop.</param>
+        /// <returns>The completed <see cref="GetTaskResponse"/>.</returns>
+        /// <exception cref="GetStreamTaskException">Task observed with <c>status == "failed"</c>.</exception>
+        /// <exception cref="GetStreamTransportException">Timeout elapsed before terminal state.</exception>
+        public async Task<GetTaskResponse> WaitForTaskAsync(
+            string taskId,
+            TimeSpan? pollInterval = null,
+            TimeSpan? timeout = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(taskId)) throw new ArgumentException("taskId is required", nameof(taskId));
+
+            var interval = pollInterval ?? TimeSpan.FromSeconds(1);
+            var max = timeout ?? TimeSpan.FromSeconds(60);
+            if (interval <= TimeSpan.Zero) interval = TimeSpan.FromSeconds(1);
+
+            var deadline = DateTime.UtcNow + max;
+            var pathParams = new Dictionary<string, string> { ["id"] = taskId };
+
+            while (true)
+            {
+                var resp = await MakeRequestAsync<object, GetTaskResponse>(
+                    "GET", "/api/v2/tasks/{id}", null, null, pathParams, cancellationToken);
+
+                var data = resp.Data;
+                if (data != null)
+                {
+                    if (string.Equals(data.Status, "completed", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return data;
+                    }
+                    if (string.Equals(data.Status, "failed", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var err = data.Error;
+                        throw new GetStreamTaskException(
+                            taskId: taskId,
+                            errorType: err?.Type ?? string.Empty,
+                            description: err?.Description ?? string.Empty,
+                            stackTrace: err?.Stacktrace,
+                            version: err?.Version);
+                    }
+                }
+
+                if (DateTime.UtcNow + interval > deadline)
+                {
+                    throw new GetStreamTransportException(
+                        $"timed out waiting for task {taskId} after {max}",
+                        "timeout",
+                        new TimeoutException($"WaitForTaskAsync deadline of {max} exceeded"));
+                }
+                await Task.Delay(interval, cancellationToken);
+            }
         }
     }
 }

--- a/src/CustomCode.cs
+++ b/src/CustomCode.cs
@@ -4,11 +4,8 @@ using GetStream.Models;
 
 namespace GetStream
 {
-    // Exception types moved to Exceptions.cs (CHA-2958). The three dead
-    // per-status subclasses (GetStreamAuthenticationException,
-    // GetStreamValidationException, GetStreamFeedException) were deleted:
-    // they were never thrown and never documented. Per-status handling now
-    // uses: catch (GetStreamApiException e) when (e.StatusCode is 401 or 403).
+    // Exception types live in Exceptions.cs. For per-status handling use:
+    // catch (GetStreamApiException e) when (e.StatusCode is 401 or 403).
 
     /// <summary>
     /// Custom JSON converter for handling nanosecond timestamps

--- a/src/CustomCode.cs
+++ b/src/CustomCode.cs
@@ -4,84 +4,11 @@ using GetStream.Models;
 
 namespace GetStream
 {
-    /// <summary>
-    /// Base exception for GetStream SDK errors
-    /// </summary>
-    public class GetStreamException : Exception
-    {
-        public GetStreamException(string message) : base(message) { }
-        public GetStreamException(string message, Exception innerException) : base(message, innerException) { }
-    }
-
-    /// <summary>
-    /// Exception thrown when API credentials are missing or invalid
-    /// </summary>
-    public class GetStreamAuthenticationException : GetStreamException
-    {
-        public GetStreamAuthenticationException(string message) : base(message) { }
-        public GetStreamAuthenticationException(string message, Exception innerException) : base(message, innerException) { }
-    }
-
-    /// <summary>
-    /// Exception thrown when API requests fail
-    /// </summary>
-    public class GetStreamApiException : GetStreamException
-    {
-        public int StatusCode { get; }
-        public string ResponseBody { get; }
-
-        public GetStreamApiException(string message, int statusCode, string responseBody)
-            : base(message)
-        {
-            StatusCode = statusCode;
-            ResponseBody = responseBody;
-        }
-
-        public GetStreamApiException(string message, int statusCode, string responseBody, Exception innerException)
-            : base(message, innerException)
-        {
-            StatusCode = statusCode;
-            ResponseBody = responseBody;
-        }
-    }
-
-    /// <summary>
-    /// Exception thrown when feed operations fail
-    /// </summary>
-    public class GetStreamFeedException : GetStreamException
-    {
-        public string FeedId { get; }
-
-        public GetStreamFeedException(string message, string feedId) : base(message)
-        {
-            FeedId = feedId;
-        }
-
-        public GetStreamFeedException(string message, string feedId, Exception innerException)
-            : base(message, innerException)
-        {
-            FeedId = feedId;
-        }
-    }
-
-    /// <summary>
-    /// Exception thrown when validation fails
-    /// </summary>
-    public class GetStreamValidationException : GetStreamException
-    {
-        public string FieldName { get; }
-
-        public GetStreamValidationException(string message, string fieldName) : base(message)
-        {
-            FieldName = fieldName;
-        }
-
-        public GetStreamValidationException(string message, string fieldName, Exception innerException)
-            : base(message, innerException)
-        {
-            FieldName = fieldName;
-        }
-    }
+    // Exception types moved to Exceptions.cs (CHA-2958). The three dead
+    // per-status subclasses (GetStreamAuthenticationException,
+    // GetStreamValidationException, GetStreamFeedException) were deleted:
+    // they were never thrown and never documented. Per-status handling now
+    // uses: catch (GetStreamApiException e) when (e.StatusCode is 401 or 403).
 
     /// <summary>
     /// Custom JSON converter for handling nanosecond timestamps

--- a/src/Exceptions.cs
+++ b/src/Exceptions.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+
+namespace GetStream
+{
+    /// <summary>
+    /// Abstract base for all SDK exceptions. CHA-2958 §4.
+    /// </summary>
+    public class GetStreamException : Exception
+    {
+        public GetStreamException(string message) : base(message) { }
+        public GetStreamException(string message, Exception? innerException) : base(message, innerException) { }
+    }
+
+    /// <summary>
+    /// Thrown when the backend returns 4xx/5xx with a parsable APIError envelope,
+    /// or when an HTTP response is received but the body is unparseable (§6.3).
+    /// CHA-2958 §5.1.
+    /// </summary>
+    public class GetStreamApiException : GetStreamException
+    {
+        public int StatusCode { get; }
+        public int Code { get; }
+        public IReadOnlyDictionary<string, string> ExceptionFields { get; }
+        public bool Unrecoverable { get; }
+        public string RawResponseBody { get; }
+        public string? MoreInfo { get; }
+        public object? Details { get; }
+
+        // Back-compat alias: FEEDS_V2_TO_V3_MIGRATION.md documents `ResponseBody`.
+        [Obsolete("Use RawResponseBody")]
+        public string ResponseBody => RawResponseBody;
+
+        public GetStreamApiException(
+            string message,
+            int statusCode,
+            int code,
+            IReadOnlyDictionary<string, string> exceptionFields,
+            bool unrecoverable,
+            string rawResponseBody,
+            string? moreInfo = null,
+            object? details = null,
+            Exception? innerException = null)
+            : base(message, innerException)
+        {
+            StatusCode = statusCode;
+            Code = code;
+            ExceptionFields = exceptionFields ?? new Dictionary<string, string>();
+            Unrecoverable = unrecoverable;
+            RawResponseBody = rawResponseBody ?? string.Empty;
+            MoreInfo = moreInfo;
+            Details = details;
+        }
+    }
+
+    /// <summary>
+    /// Thrown on HTTP 429. Subclass of <see cref="GetStreamApiException"/> so a
+    /// single <c>catch (GetStreamApiException)</c> still handles it. CHA-2958 §5.2.
+    /// </summary>
+    public class GetStreamRateLimitException : GetStreamApiException
+    {
+        /// <summary>
+        /// Parsed from the <c>Retry-After</c> response header (RFC 7231 §7.1.3).
+        /// Null when the header is absent or unparseable.
+        /// </summary>
+        public TimeSpan? RetryAfter { get; }
+
+        public GetStreamRateLimitException(
+            string message,
+            int statusCode,
+            int code,
+            IReadOnlyDictionary<string, string> exceptionFields,
+            bool unrecoverable,
+            string rawResponseBody,
+            TimeSpan? retryAfter,
+            string? moreInfo = null,
+            object? details = null,
+            Exception? innerException = null)
+            : base(message, statusCode, code, exceptionFields, unrecoverable, rawResponseBody, moreInfo, details, innerException)
+        {
+            RetryAfter = retryAfter;
+        }
+    }
+
+    /// <summary>
+    /// Thrown when a transport-layer failure prevents an HTTP response from
+    /// being received (connection reset, timeout, DNS, TLS). CHA-2958 §5.3.
+    /// </summary>
+    public class GetStreamTransportException : GetStreamException
+    {
+        /// <summary>
+        /// One of: <c>connection_reset</c>, <c>timeout</c>, <c>dns_failure</c>,
+        /// <c>tls_handshake_failed</c>, <c>unknown</c>. Matches the logging
+        /// spec §6.4 <c>error.type</c> enum.
+        /// </summary>
+        public string ErrorType { get; }
+
+        public GetStreamTransportException(string message, string errorType, Exception? innerException = null)
+            : base(message, innerException)
+        {
+            ErrorType = errorType;
+        }
+    }
+
+    /// <summary>
+    /// Thrown by <c>WaitForTaskAsync</c> when an async task completes with
+    /// status <c>failed</c>. Fields are extracted from the task's
+    /// <c>ErrorResult</c>. CHA-2958 §5.4.
+    /// </summary>
+    public class GetStreamTaskException : GetStreamException
+    {
+        public string TaskId { get; }
+        public string ErrorType { get; }
+        public string Description { get; }
+        public new string? StackTrace { get; }
+        public string? Version { get; }
+
+        public GetStreamTaskException(
+            string taskId,
+            string errorType,
+            string description,
+            string? stackTrace = null,
+            string? version = null,
+            Exception? innerException = null)
+            : base($"task {taskId} failed: {description}", innerException)
+        {
+            TaskId = taskId;
+            ErrorType = errorType;
+            Description = description;
+            StackTrace = stackTrace;
+            Version = version;
+        }
+    }
+}

--- a/src/Exceptions.cs
+++ b/src/Exceptions.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace GetStream
 {
     /// <summary>
-    /// Abstract base for all SDK exceptions. CHA-2958 §4.
+    /// Abstract base for all SDK exceptions.
     /// </summary>
     public class GetStreamException : Exception
     {
@@ -14,8 +14,7 @@ namespace GetStream
 
     /// <summary>
     /// Thrown when the backend returns 4xx/5xx with a parsable APIError envelope,
-    /// or when an HTTP response is received but the body is unparseable (§6.3).
-    /// CHA-2958 §5.1.
+    /// or when an HTTP response is received but the body is unparseable.
     /// </summary>
     public class GetStreamApiException : GetStreamException
     {
@@ -27,7 +26,7 @@ namespace GetStream
         public string? MoreInfo { get; }
         public object? Details { get; }
 
-        // Back-compat alias: FEEDS_V2_TO_V3_MIGRATION.md documents `ResponseBody`.
+        // Back-compat alias for RawResponseBody.
         [Obsolete("Use RawResponseBody")]
         public string ResponseBody => RawResponseBody;
 
@@ -55,12 +54,12 @@ namespace GetStream
 
     /// <summary>
     /// Thrown on HTTP 429. Subclass of <see cref="GetStreamApiException"/> so a
-    /// single <c>catch (GetStreamApiException)</c> still handles it. CHA-2958 §5.2.
+    /// single <c>catch (GetStreamApiException)</c> still handles it.
     /// </summary>
     public class GetStreamRateLimitException : GetStreamApiException
     {
         /// <summary>
-        /// Parsed from the <c>Retry-After</c> response header (RFC 7231 §7.1.3).
+        /// Parsed from the <c>Retry-After</c> response header.
         /// Null when the header is absent or unparseable.
         /// </summary>
         public TimeSpan? RetryAfter { get; }
@@ -84,14 +83,14 @@ namespace GetStream
 
     /// <summary>
     /// Thrown when a transport-layer failure prevents an HTTP response from
-    /// being received (connection reset, timeout, DNS, TLS). CHA-2958 §5.3.
+    /// being received (connection reset, timeout, DNS, TLS).
     /// </summary>
     public class GetStreamTransportException : GetStreamException
     {
         /// <summary>
         /// One of: <c>connection_reset</c>, <c>timeout</c>, <c>dns_failure</c>,
-        /// <c>tls_handshake_failed</c>, <c>unknown</c>. Matches the logging
-        /// spec §6.4 <c>error.type</c> enum.
+        /// <c>tls_handshake_failed</c>, <c>unknown</c>. Matches the logged
+        /// <c>error.type</c> enum.
         /// </summary>
         public string ErrorType { get; }
 
@@ -105,7 +104,7 @@ namespace GetStream
     /// <summary>
     /// Thrown by <c>WaitForTaskAsync</c> when an async task completes with
     /// status <c>failed</c>. Fields are extracted from the task's
-    /// <c>ErrorResult</c>. CHA-2958 §5.4.
+    /// <c>ErrorResult</c>.
     /// </summary>
     public class GetStreamTaskException : GetStreamException
     {

--- a/tests/ErrorHandlingTests.cs
+++ b/tests/ErrorHandlingTests.cs
@@ -217,7 +217,7 @@ namespace GetStream.Tests
         [Test]
         public void MakeRequestAsync_CallerCancellationPropagatesNatively()
         {
-            // Caller-supplied cancellation is NOT a transport error per the spec.
+            // Caller-supplied cancellation propagates natively (not a transport error).
             var handler = new BlockingHandler();
             var client = BuildClientWith(handler);
             using var cts = new CancellationTokenSource();

--- a/tests/ErrorHandlingTests.cs
+++ b/tests/ErrorHandlingTests.cs
@@ -135,7 +135,8 @@ namespace GetStream.Tests
         public void ParseRetryAfter_NegativeInteger_ClampsToZero()
         {
             var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
-            resp.Headers.Add("Retry-After", "-5");
+            // HttpHeaders.Add validates Retry-After; bypass to test the SDK's own parser.
+            resp.Headers.TryAddWithoutValidation("Retry-After", "-5");
             var result = InvokeParseRetryAfter(resp, DateTimeOffset.UtcNow);
             Assert.That(result, Is.EqualTo(TimeSpan.Zero));
         }
@@ -172,7 +173,7 @@ namespace GetStream.Tests
         public void ParseRetryAfter_Garbage_ReturnsNull()
         {
             var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
-            resp.Headers.Add("Retry-After", "not-a-date");
+            resp.Headers.TryAddWithoutValidation("Retry-After", "not-a-date");
             var result = InvokeParseRetryAfter(resp, DateTimeOffset.UtcNow);
             Assert.That(result, Is.Null);
         }
@@ -300,8 +301,8 @@ namespace GetStream.Tests
         {
             var handler = new ScriptedTaskHandler(new[]
             {
-                JsonSerializer.Serialize(new GetTaskResponse { TaskID = "t-1", Status = "pending" }),
-                JsonSerializer.Serialize(new GetTaskResponse { TaskID = "t-1", Status = "completed" }),
+                BuildTaskResponseJson("t-1", "pending"),
+                BuildTaskResponseJson("t-1", "completed"),
             });
             var client = BuildClientWith(handler);
             var result = await client.WaitForTaskAsync(
@@ -315,19 +316,8 @@ namespace GetStream.Tests
         [Test]
         public void WaitForTaskAsync_TaskFailed_ThrowsTaskException()
         {
-            var failed = new GetTaskResponse
-            {
-                TaskID = "t-2",
-                Status = "failed",
-                Error = new ErrorResult
-                {
-                    Type = "ImportError",
-                    Description = "row 7 invalid",
-                    Stacktrace = "frame-1",
-                    Version = "v1",
-                },
-            };
-            var handler = new ScriptedTaskHandler(new[] { JsonSerializer.Serialize(failed) });
+            var errJson = "{\"type\":\"ImportError\",\"description\":\"row 7 invalid\",\"stacktrace\":\"frame-1\",\"version\":\"v1\"}";
+            var handler = new ScriptedTaskHandler(new[] { BuildTaskResponseJson("t-2", "failed", errJson) });
             var client = BuildClientWith(handler);
             var ex = Assert.ThrowsAsync<GetStreamTaskException>(async () =>
                 await client.WaitForTaskAsync(
@@ -344,7 +334,7 @@ namespace GetStream.Tests
         [Test]
         public void WaitForTaskAsync_Timeout_ThrowsTransportExceptionWithTimeoutType()
         {
-            var pending = JsonSerializer.Serialize(new GetTaskResponse { TaskID = "t-3", Status = "running" });
+            var pending = BuildTaskResponseJson("t-3", "running");
             var handler = new ScriptedTaskHandler(Enumerable.Repeat(pending, 100).ToArray());
             var client = BuildClientWith(handler);
             var ex = Assert.ThrowsAsync<GetStreamTransportException>(async () =>
@@ -366,6 +356,24 @@ namespace GetStream.Tests
                 ApiSecret = DummySecret,
                 HttpClient = http,
             });
+        }
+
+        // Hand-build the task-response JSON so unit tests don't trip the
+        // NanosecondTimestampConverter on default DateTime values.
+        private static string BuildTaskResponseJson(string taskId, string status, string? errorJson = null)
+        {
+            var sb = new StringBuilder("{");
+            sb.Append("\"task_id\":\"").Append(taskId).Append("\",");
+            sb.Append("\"status\":\"").Append(status).Append("\",");
+            sb.Append("\"duration\":\"0ms\",");
+            sb.Append("\"created_at\":\"2026-05-28T12:00:00Z\",");
+            sb.Append("\"updated_at\":\"2026-05-28T12:00:00Z\"");
+            if (errorJson != null)
+            {
+                sb.Append(",\"error\":").Append(errorJson);
+            }
+            sb.Append("}");
+            return sb.ToString();
         }
 
         private static TimeSpan? InvokeParseRetryAfter(HttpResponseMessage resp, DateTimeOffset now)

--- a/tests/ErrorHandlingTests.cs
+++ b/tests/ErrorHandlingTests.cs
@@ -1,0 +1,443 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using GetStream;
+using GetStream.Models;
+using NUnit.Framework;
+
+namespace GetStream.Tests
+{
+    [TestFixture]
+    public class ErrorHandlingTests
+    {
+        private const string DummyApiKey = "dummy-api-key";
+        private const string DummySecret = "dummy-secret-that-is-long-enough-for-hmac-sha256";
+
+        // -- Hierarchy + field-population unit tests --------------------------------------
+
+        [Test]
+        public void GetStreamApiException_PopulatesAllFields()
+        {
+            var inner = new InvalidOperationException("inner");
+            var fields = new Dictionary<string, string> { ["name"] = "required" };
+            var ex = new GetStreamApiException(
+                message: "bad request",
+                statusCode: 400,
+                code: 4,
+                exceptionFields: fields,
+                unrecoverable: true,
+                rawResponseBody: "{\"code\":4}",
+                moreInfo: "https://example/info",
+                details: new List<int> { 1, 2 },
+                innerException: inner);
+
+            Assert.That(ex, Is.InstanceOf<GetStreamException>());
+            Assert.That(ex.StatusCode, Is.EqualTo(400));
+            Assert.That(ex.Code, Is.EqualTo(4));
+            Assert.That(ex.ExceptionFields["name"], Is.EqualTo("required"));
+            Assert.That(ex.Unrecoverable, Is.True);
+            Assert.That(ex.RawResponseBody, Is.EqualTo("{\"code\":4}"));
+            Assert.That(ex.MoreInfo, Is.EqualTo("https://example/info"));
+            Assert.That(ex.Details, Is.Not.Null);
+            Assert.That(ex.InnerException, Is.SameAs(inner));
+        }
+
+        [Test]
+        public void GetStreamApiException_NullExceptionFields_BecomesEmptyMap()
+        {
+            var ex = new GetStreamApiException(
+                message: "x", statusCode: 500, code: 0,
+                exceptionFields: null!, unrecoverable: false,
+                rawResponseBody: "");
+            Assert.That(ex.ExceptionFields, Is.Not.Null);
+            Assert.That(ex.ExceptionFields.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void GetStreamRateLimitException_IsApiException_AndCarriesRetryAfter()
+        {
+            var ex = new GetStreamRateLimitException(
+                message: "rate limited", statusCode: 429, code: 9,
+                exceptionFields: new Dictionary<string, string>(),
+                unrecoverable: false, rawResponseBody: "{}",
+                retryAfter: TimeSpan.FromSeconds(30));
+
+            Assert.That(ex, Is.InstanceOf<GetStreamApiException>());
+            Assert.That(ex, Is.InstanceOf<GetStreamException>());
+            Assert.That(ex.StatusCode, Is.EqualTo(429));
+            Assert.That(ex.RetryAfter, Is.EqualTo(TimeSpan.FromSeconds(30)));
+        }
+
+        [Test]
+        public void GetStreamTransportException_PreservesInnerException()
+        {
+            var inner = new SocketException((int)SocketError.ConnectionReset);
+            var ex = new GetStreamTransportException("boom", "connection_reset", inner);
+            Assert.That(ex, Is.InstanceOf<GetStreamException>());
+            Assert.That(ex.ErrorType, Is.EqualTo("connection_reset"));
+            Assert.That(ex.InnerException, Is.SameAs(inner));
+        }
+
+        [Test]
+        public void GetStreamTaskException_HasAllFields_AndShadowedStackTrace()
+        {
+            var ex = new GetStreamTaskException(
+                taskId: "t-1",
+                errorType: "ImportError",
+                description: "boom",
+                stackTrace: "frame-1",
+                version: "v1");
+            Assert.That(ex.TaskId, Is.EqualTo("t-1"));
+            Assert.That(ex.ErrorType, Is.EqualTo("ImportError"));
+            Assert.That(ex.Description, Is.EqualTo("boom"));
+            Assert.That(ex.StackTrace, Is.EqualTo("frame-1"));
+            Assert.That(ex.Version, Is.EqualTo("v1"));
+        }
+
+        // -- Regression: deleted subclasses must not return -------------------------------
+
+        [Test]
+        public void DeletedSubclasses_NoLongerExistOnAssembly()
+        {
+            var asm = typeof(GetStreamException).Assembly;
+            foreach (var name in new[]
+            {
+                "GetStream.GetStreamAuthenticationException",
+                "GetStream.GetStreamValidationException",
+                "GetStream.GetStreamFeedException",
+            })
+            {
+                Assert.That(asm.GetType(name, throwOnError: false), Is.Null,
+                    $"{name} was deleted in CHA-2958 and must not be reintroduced");
+            }
+        }
+
+        // -- Retry-After parsing ----------------------------------------------------------
+
+        [Test]
+        public void ParseRetryAfter_IntegerSeconds_ReturnsExactDuration()
+        {
+            var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            resp.Headers.Add("Retry-After", "30");
+            var result = InvokeParseRetryAfter(resp, DateTimeOffset.UtcNow);
+            Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(30)));
+        }
+
+        [Test]
+        public void ParseRetryAfter_NegativeInteger_ClampsToZero()
+        {
+            var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            resp.Headers.Add("Retry-After", "-5");
+            var result = InvokeParseRetryAfter(resp, DateTimeOffset.UtcNow);
+            Assert.That(result, Is.EqualTo(TimeSpan.Zero));
+        }
+
+        [Test]
+        public void ParseRetryAfter_HttpDate_ReturnsCorrectDelta()
+        {
+            var now = new DateTimeOffset(2026, 5, 28, 12, 0, 0, TimeSpan.Zero);
+            var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            resp.Headers.Add("Retry-After", "Thu, 28 May 2026 12:01:00 GMT");
+            var result = InvokeParseRetryAfter(resp, now);
+            Assert.That(result, Is.EqualTo(TimeSpan.FromMinutes(1)));
+        }
+
+        [Test]
+        public void ParseRetryAfter_PastHttpDate_ReturnsZero()
+        {
+            var now = new DateTimeOffset(2026, 5, 28, 12, 0, 0, TimeSpan.Zero);
+            var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            resp.Headers.Add("Retry-After", "Thu, 28 May 2026 11:59:00 GMT");
+            var result = InvokeParseRetryAfter(resp, now);
+            Assert.That(result, Is.EqualTo(TimeSpan.Zero));
+        }
+
+        [Test]
+        public void ParseRetryAfter_HeaderMissing_ReturnsNull()
+        {
+            var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            var result = InvokeParseRetryAfter(resp, DateTimeOffset.UtcNow);
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void ParseRetryAfter_Garbage_ReturnsNull()
+        {
+            var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            resp.Headers.Add("Retry-After", "not-a-date");
+            var result = InvokeParseRetryAfter(resp, DateTimeOffset.UtcNow);
+            Assert.That(result, Is.Null);
+        }
+
+        // -- Transport-error wrapping (no live network) -----------------------------------
+
+        [Test]
+        public void MakeRequestAsync_HttpRequestExceptionWithSocketReset_BecomesTransportException()
+        {
+            var inner = new HttpRequestException("reset", new SocketException((int)SocketError.ConnectionReset));
+            var client = BuildClientWith(new ThrowingHandler(inner));
+            var ex = Assert.ThrowsAsync<GetStreamTransportException>(async () =>
+                await client.MakeRequestAsync<object, object>(
+                    "GET", "/anything", null, null, null));
+            Assert.That(ex!.ErrorType, Is.EqualTo("connection_reset"));
+            Assert.That(ex.InnerException, Is.SameAs(inner));
+        }
+
+        [Test]
+        public void MakeRequestAsync_DnsFailure_ClassifiedAsDnsFailure()
+        {
+            var inner = new HttpRequestException("dns", new SocketException((int)SocketError.HostNotFound));
+            var client = BuildClientWith(new ThrowingHandler(inner));
+            var ex = Assert.ThrowsAsync<GetStreamTransportException>(async () =>
+                await client.MakeRequestAsync<object, object>(
+                    "GET", "/anything", null, null, null));
+            Assert.That(ex!.ErrorType, Is.EqualTo("dns_failure"));
+        }
+
+        [Test]
+        public void MakeRequestAsync_TimeoutException_ClassifiedAsTimeout()
+        {
+            var inner = new TimeoutException("slow");
+            var client = BuildClientWith(new ThrowingHandler(inner));
+            var ex = Assert.ThrowsAsync<GetStreamTransportException>(async () =>
+                await client.MakeRequestAsync<object, object>(
+                    "GET", "/anything", null, null, null));
+            Assert.That(ex!.ErrorType, Is.EqualTo("timeout"));
+        }
+
+        [Test]
+        public void MakeRequestAsync_CallerCancellationPropagatesNatively()
+        {
+            // Caller-supplied cancellation is NOT a transport error per the spec.
+            var handler = new BlockingHandler();
+            var client = BuildClientWith(handler);
+            using var cts = new CancellationTokenSource();
+            cts.CancelAfter(TimeSpan.FromMilliseconds(50));
+            Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                await client.MakeRequestAsync<object, object>(
+                    "GET", "/slow", null, null, null, cts.Token));
+        }
+
+        // -- HTTP API error parsing -------------------------------------------------------
+
+        [Test]
+        public void MakeRequestAsync_ApiError_PopulatesFromEnvelope()
+        {
+            var body = JsonSerializer.Serialize(new APIError
+            {
+                Code = 4,
+                Message = "input invalid",
+                Unrecoverable = true,
+                ExceptionFields = new Dictionary<string, string> { ["name"] = "required" },
+                MoreInfo = "https://x/info",
+                StatusCode = 400,
+            });
+            var client = BuildClientWith(new CannedHandler(HttpStatusCode.BadRequest, body));
+            var ex = Assert.ThrowsAsync<GetStreamApiException>(async () =>
+                await client.MakeRequestAsync<object, object>(
+                    "GET", "/anything", null, null, null));
+            Assert.That(ex!.StatusCode, Is.EqualTo(400));
+            Assert.That(ex.Code, Is.EqualTo(4));
+            Assert.That(ex.Message, Is.EqualTo("input invalid"));
+            Assert.That(ex.Unrecoverable, Is.True);
+            Assert.That(ex.ExceptionFields["name"], Is.EqualTo("required"));
+            Assert.That(ex.MoreInfo, Is.EqualTo("https://x/info"));
+            Assert.That(ex.RawResponseBody, Is.EqualTo(body));
+        }
+
+        [Test]
+        public void MakeRequestAsync_UnparseableBody_FallsThroughToUnparseablePath()
+        {
+            var client = BuildClientWith(new CannedHandler(HttpStatusCode.InternalServerError, "<html>oops</html>"));
+            var ex = Assert.ThrowsAsync<GetStreamApiException>(async () =>
+                await client.MakeRequestAsync<object, object>(
+                    "GET", "/anything", null, null, null));
+            Assert.That(ex!.StatusCode, Is.EqualTo(500));
+            Assert.That(ex.Code, Is.EqualTo(0));
+            Assert.That(ex.Message, Is.EqualTo("failed to parse error response"));
+            Assert.That(ex.RawResponseBody, Is.EqualTo("<html>oops</html>"));
+            Assert.That(ex.ExceptionFields.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void MakeRequestAsync_429WithRetryAfterSeconds_ThrowsRateLimitException()
+        {
+            var body = JsonSerializer.Serialize(new APIError { Code = 9, Message = "slow down" });
+            var headers = new Dictionary<string, string> { ["Retry-After"] = "42" };
+            var client = BuildClientWith(new CannedHandler(HttpStatusCode.TooManyRequests, body, headers));
+            var ex = Assert.ThrowsAsync<GetStreamRateLimitException>(async () =>
+                await client.MakeRequestAsync<object, object>(
+                    "GET", "/anything", null, null, null));
+            Assert.That(ex!.RetryAfter, Is.EqualTo(TimeSpan.FromSeconds(42)));
+            Assert.That(ex.Code, Is.EqualTo(9));
+            Assert.That(ex, Is.InstanceOf<GetStreamApiException>(),
+                "rate-limit exception must still satisfy catch (GetStreamApiException)");
+        }
+
+        [Test]
+        public void MakeRequestAsync_429WithoutRetryAfter_ReturnsNullRetryAfter()
+        {
+            var body = JsonSerializer.Serialize(new APIError { Code = 9, Message = "slow" });
+            var client = BuildClientWith(new CannedHandler(HttpStatusCode.TooManyRequests, body));
+            var ex = Assert.ThrowsAsync<GetStreamRateLimitException>(async () =>
+                await client.MakeRequestAsync<object, object>(
+                    "GET", "/anything", null, null, null));
+            Assert.That(ex!.RetryAfter, Is.Null);
+        }
+
+        // -- WaitForTaskAsync -------------------------------------------------------------
+
+        [Test]
+        public async Task WaitForTaskAsync_TaskCompleted_ReturnsTask()
+        {
+            var handler = new ScriptedTaskHandler(new[]
+            {
+                JsonSerializer.Serialize(new GetTaskResponse { TaskID = "t-1", Status = "pending" }),
+                JsonSerializer.Serialize(new GetTaskResponse { TaskID = "t-1", Status = "completed" }),
+            });
+            var client = BuildClientWith(handler);
+            var result = await client.WaitForTaskAsync(
+                "t-1",
+                pollInterval: TimeSpan.FromMilliseconds(10),
+                timeout: TimeSpan.FromSeconds(5));
+            Assert.That(result.Status, Is.EqualTo("completed"));
+            Assert.That(handler.CallCount, Is.GreaterThanOrEqualTo(2));
+        }
+
+        [Test]
+        public void WaitForTaskAsync_TaskFailed_ThrowsTaskException()
+        {
+            var failed = new GetTaskResponse
+            {
+                TaskID = "t-2",
+                Status = "failed",
+                Error = new ErrorResult
+                {
+                    Type = "ImportError",
+                    Description = "row 7 invalid",
+                    Stacktrace = "frame-1",
+                    Version = "v1",
+                },
+            };
+            var handler = new ScriptedTaskHandler(new[] { JsonSerializer.Serialize(failed) });
+            var client = BuildClientWith(handler);
+            var ex = Assert.ThrowsAsync<GetStreamTaskException>(async () =>
+                await client.WaitForTaskAsync(
+                    "t-2",
+                    pollInterval: TimeSpan.FromMilliseconds(10),
+                    timeout: TimeSpan.FromSeconds(5)));
+            Assert.That(ex!.TaskId, Is.EqualTo("t-2"));
+            Assert.That(ex.ErrorType, Is.EqualTo("ImportError"));
+            Assert.That(ex.Description, Is.EqualTo("row 7 invalid"));
+            Assert.That(ex.StackTrace, Is.EqualTo("frame-1"));
+            Assert.That(ex.Version, Is.EqualTo("v1"));
+        }
+
+        [Test]
+        public void WaitForTaskAsync_Timeout_ThrowsTransportExceptionWithTimeoutType()
+        {
+            var pending = JsonSerializer.Serialize(new GetTaskResponse { TaskID = "t-3", Status = "running" });
+            var handler = new ScriptedTaskHandler(Enumerable.Repeat(pending, 100).ToArray());
+            var client = BuildClientWith(handler);
+            var ex = Assert.ThrowsAsync<GetStreamTransportException>(async () =>
+                await client.WaitForTaskAsync(
+                    "t-3",
+                    pollInterval: TimeSpan.FromMilliseconds(30),
+                    timeout: TimeSpan.FromMilliseconds(80)));
+            Assert.That(ex!.ErrorType, Is.EqualTo("timeout"));
+        }
+
+        // -- helpers ----------------------------------------------------------------------
+
+        private static BaseClient BuildClientWith(HttpMessageHandler handler)
+        {
+            var http = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) };
+            return new BaseClient(new StreamOptions
+            {
+                ApiKey = DummyApiKey,
+                ApiSecret = DummySecret,
+                HttpClient = http,
+            });
+        }
+
+        private static TimeSpan? InvokeParseRetryAfter(HttpResponseMessage resp, DateTimeOffset now)
+        {
+            var method = typeof(BaseClient).GetMethod(
+                "ParseRetryAfter",
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+            return (TimeSpan?)method.Invoke(null, new object[] { resp, now });
+        }
+
+        private sealed class ThrowingHandler : HttpMessageHandler
+        {
+            private readonly Exception _ex;
+            public ThrowingHandler(Exception ex) { _ex = ex; }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                throw _ex;
+            }
+        }
+
+        private sealed class BlockingHandler : HttpMessageHandler
+        {
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+        }
+
+        private sealed class CannedHandler : HttpMessageHandler
+        {
+            private readonly HttpStatusCode _status;
+            private readonly string _body;
+            private readonly Dictionary<string, string>? _headers;
+            public CannedHandler(HttpStatusCode status, string body, Dictionary<string, string>? headers = null)
+            {
+                _status = status;
+                _body = body;
+                _headers = headers;
+            }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var resp = new HttpResponseMessage(_status)
+                {
+                    Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+                };
+                if (_headers != null)
+                {
+                    foreach (var kv in _headers)
+                    {
+                        resp.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
+                    }
+                }
+                return Task.FromResult(resp);
+            }
+        }
+
+        private sealed class ScriptedTaskHandler : HttpMessageHandler
+        {
+            private readonly string[] _bodies;
+            public int CallCount { get; private set; }
+            public ScriptedTaskHandler(string[] bodies) { _bodies = bodies; }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var idx = Math.Min(CallCount, _bodies.Length - 1);
+                CallCount++;
+                var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_bodies[idx], Encoding.UTF8, "application/json"),
+                };
+                return Task.FromResult(resp);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New exception hierarchy under `GetStream`:
  - `GetStreamException` (abstract base)
  - `GetStreamApiException` — parses APIError envelope; exposes StatusCode, Code, Message, ExceptionFields, Unrecoverable, RawResponseBody, MoreInfo, Details
  - `GetStreamRateLimitException : GetStreamApiException` — HTTP 429 with `RetryAfter` (TimeSpan?) parsed per RFC 7231 §7.1.3
  - `GetStreamTransportException` — network failures with `ErrorType` enum; `InnerException` preserved
  - `GetStreamTaskException` — for `WaitForTaskAsync` failures
- `BaseClient.WaitForTaskAsync(taskId, pollInterval?, timeout?, ct?)` per spec. Defaults 1s/60s.
- Deletes three dead subclasses (`GetStreamAuthenticationException`, `GetStreamValidationException`, `GetStreamFeedException`). Audit confirmed zero throw sites in `src/` and zero matches in customer docs.

## Migration

```csharp
// before
catch (GetStreamAuthenticationException ex) { ... }

// after
catch (GetStreamApiException ex) when (ex.StatusCode is 401 or 403) { ... }
```

`ResponseBody` is preserved as `[Obsolete]` alias for `RawResponseBody`.

## Test plan

- [ ] `dotnet build`
- [ ] `dotnet test tests/stream-feed-net-test.csproj --filter "FullyQualifiedName~ErrorHandlingTests"`
- [ ] `make test`
- [ ] `make test-integration` (requires credentials)