### PR TITLE
chore: derive release bump only from the title bang marker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ on:
   pull_request:
     types: [closed]
     branches:
-      - main
       - master
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,13 +66,9 @@ jobs:
         if: github.event_name == 'pull_request' && steps.already_released.outputs.value != 'true'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          PR_BODY_FILE=$(mktemp)
-          printf '%s' "$PR_BODY" > "$PR_BODY_FILE"
           bash scripts/bump_version.sh \
             --title "$PR_TITLE" \
-            --body-file "$PR_BODY_FILE" \
             --output "$GITHUB_OUTPUT"
 
       - name: Determine version bump (manual)

--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ The SDK follows .NET best practices and conventions while providing a clean, mai
 
 Releases use two paths, both handled by `.github/workflows/release.yml`:
 
-- **Default**: automatic release when a PR is merged to `main`/`master`. The PR title (and body) drives the semver bump.
+- **Default**: automatic release when a PR is merged to `master`. The PR title drives the semver bump.
 - **Fallback**: manual release via the `Release` workflow's `workflow_dispatch` (admin use). Select a `version_bump` (`patch`/`minor`/`major`). `use_current_version=true` skips the bump and publishes whatever is already in `src/stream-feed-net.csproj`.
 
 Automatic semver bump rules:
 
 - `feat:` -> minor
 - `fix:` (or `bug:`) -> patch
-- `feat!:`, `<type>(scope)!:`, or `BREAKING CHANGE` in the PR body/title -> major
+- `feat!:` or `<type>(scope)!:` (the `!` marker) -> major
 
 PRs with any other prefix do not trigger a release.
 

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -3,8 +3,6 @@
 set -euo pipefail
 
 title=""
-body=""
-body_file=""
 output=""
 manual_bump=""
 use_current_version="false"
@@ -13,14 +11,6 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --title)
       title="${2:-}"
-      shift 2
-      ;;
-    --body)
-      body="${2:-}"
-      shift 2
-      ;;
-    --body-file)
-      body_file="${2:-}"
       shift 2
       ;;
     --output)
@@ -42,19 +32,12 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -n "${body_file}" ]]; then
-  body="$(<"${body_file}")"
-fi
-
 determine_bump() {
   local pr_title="$1"
-  local pr_body="$2"
 
-  if [[ "${pr_body}" =~ BREAKING[[:space:]-]CHANGE ]] || [[ "${pr_title}" =~ BREAKING[[:space:]-]CHANGE ]]; then
-    echo "major"
-    return
-  fi
-
+  # Breaking changes are signalled only by the `!` marker in the title
+  # (e.g. `feat!:`). Free-text body/title prose is not trusted: a PR that
+  # merely mentions the major-bump phrase must not force a major bump.
   if ! echo "${pr_title}" | grep -Eq '^([a-zA-Z]+)(\([^)]+\))?(!)?:'; then
     echo "none"
     return
@@ -158,7 +141,7 @@ if [[ -n "${manual_bump_normalized}" ]]; then
   exit 0
 fi
 
-bump="$(determine_bump "${title}" "${body}")"
+bump="$(determine_bump "${title}")"
 
 if [[ "${bump}" == "none" ]]; then
   write_output "should_release" "false"


### PR DESCRIPTION
## Problem
`scripts/bump_version.sh` (`determine_bump`) forced a major bump whenever the conventional-commits major-bump phrase appeared anywhere in the PR title or body. Any PR that merely references the phrase, including a sentence saying there is none, trips it. Same footgun already fixed in getstream-ruby (#66) and stream-py (#268).

## Fix
- Trust only the conventional-commits `!` marker in the title (e.g. `feat!:`) as the major signal. Stop reading the PR body entirely, and remove the now-dead `--body` / `--body-file` options plus the body plumbing in `release.yml`.
- Align the release trigger to `master`: the workflow listed both `main` and `master`, but this repo's default branch is `master` and there is no `main`, so `- main` was dead config. Now `- master` only.

Bump rules after this change (title-only):
- `feat!:` / `fix!:` / `type(scope)!:` -> major
- `feat:` -> minor
- `fix:` / `bug:` -> patch
- anything else -> no release

This PR is titled `chore:` so it does not trigger a release.

## Verification
Ran the real script across cases via a bash harness (literal titles):
- `feat:` -> minor; `feat!:` / `feat(mod)!:` / `fix!:` -> major; `fix:` / `bug:` -> patch; `chore:` -> none
- a `feat:` title whose body references the major-bump phrase -> **minor** (the regression); a prose-only title -> none

`bash -n` clean.