### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
 jobs:
   build-and-test:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"


### PR DESCRIPTION
## Summary
- Add explicit least-privilege permissions blocks to 1 workflow.
- Resolves 1 open CodeQL actions/missing-workflow-permissions alert.

## Linear
- [APPSEC-236](https://linear.app/stream/issue/APPSEC-236)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge

Made with [Cursor](https://cursor.com)