### PR TITLE
ci: verify dotnet format in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
     
     - name: Restore dependencies
       run: dotnet restore
+
+    - name: Verify formatting
+      run: dotnet format --verify-no-changes
       
     - name: Build (Debug)
       run: dotnet build --no-restore --configuration Debug


### PR DESCRIPTION
## Summary
- Add `dotnet format --verify-no-changes` to `.github/workflows/ci.yml` after restore
- Catches unformatted OpenAPI regen output (e.g. missing post-`generate.sh` format step) before merge

## Test plan
- [x] `dotnet format --verify-no-changes` passes on `master` locally
- [ ] CI passes on this PR
- [ ] PRs with unformatted generated code (e.g. #57) should fail the new step


Made with [Cursor](https://cursor.com)