### PR TITLE
feat: [FEEDS-1651] Regenerate from OpenAPI

### DIFF
--- a/src/FeedsV3Client.cs
+++ b/src/FeedsV3Client.cs
@@ -104,10 +104,11 @@ namespace GetStream
         public async Task<StreamResponse<QueryActivitiesResponse>> QueryActivitiesAsync(QueryActivitiesRequest request,
             CancellationToken cancellationToken = default)
         {
+            var queryParams = ExtractQueryParams(request);
 
             var result = await _client.MakeRequestAsync<QueryActivitiesRequest, QueryActivitiesResponse>(
                 "POST",
-                "/api/v2/feeds/activities/query", null, request, null,
+                "/api/v2/feeds/activities/query", queryParams, request, null,
                 cancellationToken);
 
             return result;
@@ -359,6 +360,21 @@ namespace GetStream
 
             return result;
         }
+        public async Task<StreamResponse<TranslateActivityResponse>> TranslateActivityAsync(string id, TranslateActivityRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var pathParams = new Dictionary<string, string>
+            {
+                ["id"] = id,
+            };
+
+            var result = await _client.MakeRequestAsync<TranslateActivityRequest, TranslateActivityResponse>(
+                "POST",
+                "/api/v2/feeds/activities/{id}/translate", null, request, pathParams,
+                cancellationToken);
+
+            return result;
+        }
         public async Task<StreamResponse<QueryBookmarkFoldersResponse>> QueryBookmarkFoldersAsync(QueryBookmarkFoldersRequest request,
             CancellationToken cancellationToken = default)
         {
@@ -403,10 +419,11 @@ namespace GetStream
         public async Task<StreamResponse<QueryBookmarksResponse>> QueryBookmarksAsync(QueryBookmarksRequest request,
             CancellationToken cancellationToken = default)
         {
+            var queryParams = ExtractQueryParams(request);
 
             var result = await _client.MakeRequestAsync<QueryBookmarksRequest, QueryBookmarksResponse>(
                 "POST",
-                "/api/v2/feeds/bookmarks/query", null, request, null,
+                "/api/v2/feeds/bookmarks/query", queryParams, request, null,
                 cancellationToken);
 
             return result;
@@ -516,10 +533,11 @@ namespace GetStream
         public async Task<StreamResponse<QueryCommentsResponse>> QueryCommentsAsync(QueryCommentsRequest request,
             CancellationToken cancellationToken = default)
         {
+            var queryParams = ExtractQueryParams(request);
 
             var result = await _client.MakeRequestAsync<QueryCommentsRequest, QueryCommentsResponse>(
                 "POST",
-                "/api/v2/feeds/comments/query", null, request, null,
+                "/api/v2/feeds/comments/query", queryParams, request, null,
                 cancellationToken);
 
             return result;
@@ -721,6 +739,21 @@ namespace GetStream
 
             return result;
         }
+        public async Task<StreamResponse<TranslateCommentResponse>> TranslateCommentAsync(string id, TranslateCommentRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var pathParams = new Dictionary<string, string>
+            {
+                ["id"] = id,
+            };
+
+            var result = await _client.MakeRequestAsync<TranslateCommentRequest, TranslateCommentResponse>(
+                "POST",
+                "/api/v2/feeds/comments/{id}/translate", null, request, pathParams,
+                cancellationToken);
+
+            return result;
+        }
         public async Task<StreamResponse<ListFeedGroupsResponse>> ListFeedGroupsAsync(object request = null,
             CancellationToken cancellationToken = default)
         {
@@ -769,10 +802,11 @@ namespace GetStream
                 ["feed_group_id"] = feedGroupID,
                 ["feed_id"] = feedID,
             };
+            var queryParams = ExtractQueryParams(request);
 
             var result = await _client.MakeRequestAsync<GetOrCreateFeedRequest, GetOrCreateFeedResponse>(
                 "POST",
-                "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}", null, request, pathParams,
+                "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}", queryParams, request, pathParams,
                 cancellationToken);
 
             return result;
@@ -932,10 +966,11 @@ namespace GetStream
                 ["feed_group_id"] = feedGroupID,
                 ["feed_id"] = feedID,
             };
+            var queryParams = ExtractQueryParams(request);
 
             var result = await _client.MakeRequestAsync<QueryPinnedActivitiesRequest, QueryPinnedActivitiesResponse>(
                 "POST",
-                "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/pinned_activities/query", null, request, pathParams,
+                "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/pinned_activities/query", queryParams, request, pathParams,
                 cancellationToken);
 
             return result;

--- a/src/models.cs
+++ b/src/models.cs
@@ -1078,6 +1078,8 @@ namespace GetStream.Models
         public List<ShareResponse> LatestShares { get; set; }
         [JsonPropertyName("current_feed")]
         public FeedResponse? CurrentFeed { get; set; }
+        [JsonPropertyName("i18n")]
+        public Dictionary<string, string> I18n { get; set; }
         [JsonPropertyName("location")]
         public Location? Location { get; set; }
         [JsonPropertyName("metrics")]
@@ -2002,8 +2004,6 @@ namespace GetStream.Models
         public int MaxAggregatedActivitiesLength { get; set; }
         [JsonPropertyName("moderation_audio_call_moderation_enabled")]
         public bool ModerationAudioCallModerationEnabled { get; set; }
-        [JsonPropertyName("moderation_audio_file_enabled")]
-        public bool ModerationAudioFileEnabled { get; set; }
         [JsonPropertyName("moderation_enabled")]
         public bool ModerationEnabled { get; set; }
         [JsonPropertyName("moderation_llm_configurability_enabled")]
@@ -7868,6 +7868,8 @@ namespace GetStream.Models
         /// </summary>
         [JsonPropertyName("custom")]
         public object Custom { get; set; }
+        [JsonPropertyName("i18n")]
+        public Dictionary<string, string> I18n { get; set; }
         [JsonPropertyName("moderation")]
         public ModerationV2Response? Moderation { get; set; }
         /// <summary>
@@ -11977,6 +11979,8 @@ namespace GetStream.Models
         public List<FeedsShareResponse> LatestShares { get; set; }
         [JsonPropertyName("current_feed")]
         public FeedsFeedResponse? CurrentFeed { get; set; }
+        [JsonPropertyName("i18n")]
+        public Dictionary<string, string> I18n { get; set; }
         [JsonPropertyName("location")]
         public FeedsActivityLocation? Location { get; set; }
         [JsonPropertyName("metrics")]
@@ -12043,6 +12047,8 @@ namespace GetStream.Models
         public List<FeedsReactionResponse> LatestReactions { get; set; }
         [JsonPropertyName("custom")]
         public object Custom { get; set; }
+        [JsonPropertyName("i18n")]
+        public Dictionary<string, string> I18n { get; set; }
         [JsonPropertyName("moderation")]
         public ModerationV2Response? Moderation { get; set; }
         [JsonPropertyName("reaction_groups")]
@@ -24795,6 +24801,8 @@ namespace GetStream.Models
         public List<ThreadedCommentResponse> Replies { get; set; }
         [JsonPropertyName("custom")]
         public object Custom { get; set; }
+        [JsonPropertyName("i18n")]
+        public Dictionary<string, string> I18n { get; set; }
         [JsonPropertyName("meta")]
         public RepliesMeta? Meta { get; set; }
         [JsonPropertyName("moderation")]
@@ -24962,6 +24970,46 @@ namespace GetStream.Models
         public SpeechSegmentConfig? SpeechSegmentConfig { get; set; }
         [JsonPropertyName("translation")]
         public TranslationSettings? Translation { get; set; }
+    }
+
+    public class TranslateActivityRequest
+    {
+        /// <summary>
+        /// ISO 639-1 language code to translate to
+        /// </summary>
+        [JsonPropertyName("language")]
+        public string Language { get; set; }
+    }
+
+    public class TranslateActivityResponse
+    {
+        /// <summary>
+        /// Duration of the request in milliseconds
+        /// </summary>
+        [JsonPropertyName("duration")]
+        public string Duration { get; set; }
+        [JsonPropertyName("activity")]
+        public ActivityResponse Activity { get; set; }
+    }
+
+    public class TranslateCommentRequest
+    {
+        /// <summary>
+        /// ISO 639-1 language code to translate to
+        /// </summary>
+        [JsonPropertyName("language")]
+        public string Language { get; set; }
+    }
+
+    public class TranslateCommentResponse
+    {
+        /// <summary>
+        /// Duration of the request in milliseconds
+        /// </summary>
+        [JsonPropertyName("duration")]
+        public string Duration { get; set; }
+        [JsonPropertyName("comment")]
+        public CommentResponse Comment { get; set; }
     }
 
     public class TranslateMessageRequest
@@ -25668,6 +25716,8 @@ namespace GetStream.Models
         public int? RemindersInterval { get; set; }
         [JsonPropertyName("reminders_max_members")]
         public int? RemindersMaxMembers { get; set; }
+        [JsonPropertyName("reminders_max_per_user")]
+        public int? RemindersMaxPerUser { get; set; }
         [JsonPropertyName("revoke_tokens_issued_before")]
         public DateTime? RevokeTokensIssuedBefore { get; set; }
         [JsonPropertyName("sns_key")]

--- a/tests/FeedTests.cs
+++ b/tests/FeedTests.cs
@@ -810,6 +810,42 @@ namespace GetStream.Tests
                 It.IsAny<CancellationToken>()), Times.Once);
         }
         [Test]
+        public async Task TranslateActivityAsync_ShouldCallCorrectEndpoint()
+        {
+            // Arrange
+            var request = new TranslateActivityRequest();
+            var id = "test-id";
+
+            var expectedResponse = new StreamResponse<TranslateActivityResponse>
+            {
+                Data = new TranslateActivityResponse()
+            };
+
+            _mockClient.Setup(x => x.MakeRequestAsync<TranslateActivityRequest, TranslateActivityResponse>(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<TranslateActivityRequest>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedResponse);
+
+            // Act
+            var result = await _client.TranslateActivityAsync(id, request);
+
+            // Assert
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result, Is.EqualTo(expectedResponse));
+
+            _mockClient.Verify(x => x.MakeRequestAsync<TranslateActivityRequest, TranslateActivityResponse>(
+                "POST",
+                "/api/v2/feeds/activities/{id}/translate",
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<TranslateActivityRequest>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+        [Test]
         public async Task QueryBookmarkFoldersAsync_ShouldCallCorrectEndpoint()
         {
             // Arrange
@@ -1766,6 +1802,42 @@ namespace GetStream.Tests
                 "/api/v2/feeds/comments/{id}/restore",
                 It.IsAny<Dictionary<string, string>>(),
                 It.IsAny<RestoreCommentRequest>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+        [Test]
+        public async Task TranslateCommentAsync_ShouldCallCorrectEndpoint()
+        {
+            // Arrange
+            var request = new TranslateCommentRequest();
+            var id = "test-id";
+
+            var expectedResponse = new StreamResponse<TranslateCommentResponse>
+            {
+                Data = new TranslateCommentResponse()
+            };
+
+            _mockClient.Setup(x => x.MakeRequestAsync<TranslateCommentRequest, TranslateCommentResponse>(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<TranslateCommentRequest>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedResponse);
+
+            // Act
+            var result = await _client.TranslateCommentAsync(id, request);
+
+            // Assert
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result, Is.EqualTo(expectedResponse));
+
+            _mockClient.Verify(x => x.MakeRequestAsync<TranslateCommentRequest, TranslateCommentResponse>(
+                "POST",
+                "/api/v2/feeds/comments/{id}/translate",
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<TranslateCommentRequest>(),
                 It.IsAny<Dictionary<string, string>>(),
                 It.IsAny<CancellationToken>()), Times.Once);
         }


### PR DESCRIPTION
## Summary
Regenerates server-side SDK code from latest chat OpenAPI specs for FEEDS-1651.

## Checklist
- [x] ./generate.sh completed successfully
- [x] Local build/lint/unit tests passed
- [ ] SDK integration tests (CI)

Made with [Cursor](https://cursor.com)