### PR TITLE
feat!: rename shadowed moderation CallResponse schema (CHA-3386)

### DIFF
--- a/src/models.cs
+++ b/src/models.cs
@@ -16956,6 +16956,50 @@ namespace GetStream.Models
         public string Duration { get; set; }
     }
 
+    public class ModerationCallResponse
+    {
+        [JsonPropertyName("backstage")]
+        public bool Backstage { get; set; }
+        [JsonPropertyName("captioning")]
+        public bool Captioning { get; set; }
+        [JsonPropertyName("cid")]
+        public string Cid { get; set; }
+        [JsonPropertyName("created_at")]
+        public DateTime CreatedAt { get; set; }
+        [JsonPropertyName("current_session_id")]
+        public string CurrentSessionID { get; set; }
+        [JsonPropertyName("id")]
+        public string ID { get; set; }
+        [JsonPropertyName("recording")]
+        public bool Recording { get; set; }
+        [JsonPropertyName("transcribing")]
+        public bool Transcribing { get; set; }
+        [JsonPropertyName("translating")]
+        public bool Translating { get; set; }
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+        [JsonPropertyName("updated_at")]
+        public DateTime UpdatedAt { get; set; }
+        [JsonPropertyName("blocked_user_ids")]
+        public List<string> BlockedUserIds { get; set; }
+        [JsonPropertyName("custom")]
+        public object Custom { get; set; }
+        [JsonPropertyName("channel_cid")]
+        public string? ChannelCid { get; set; }
+        [JsonPropertyName("ended_at")]
+        public DateTime? EndedAt { get; set; }
+        [JsonPropertyName("join_ahead_time_seconds")]
+        public int? JoinAheadTimeSeconds { get; set; }
+        [JsonPropertyName("routing_number")]
+        public string? RoutingNumber { get; set; }
+        [JsonPropertyName("starts_at")]
+        public DateTime? StartsAt { get; set; }
+        [JsonPropertyName("team")]
+        public string? Team { get; set; }
+        [JsonPropertyName("created_by")]
+        public UserResponse? CreatedBy { get; set; }
+    }
+
     public class ModerationCheckCompletedEvent
     {
         [JsonPropertyName("created_at")]
@@ -22479,7 +22523,7 @@ namespace GetStream.Models
         [JsonPropertyName("assigned_to")]
         public UserResponse? AssignedTo { get; set; }
         [JsonPropertyName("call")]
-        public CallResponse? Call { get; set; }
+        public ModerationCallResponse? Call { get; set; }
         [JsonPropertyName("entity_creator")]
         public EntityCreatorResponse? EntityCreator { get; set; }
         [JsonPropertyName("escalation_metadata")]


### PR DESCRIPTION
## Summary
Regenerates the SDK from current chat master. net already shipped the GetChannel endpoint (v13.0.1/v13.1.0), so this PR carries only the CHA-3386 schema-collision fix:
- Renames the shadowed moderation `CallResponse` to `ModerationCallResponse` (the video `CallResponse` keeps its name). The moderation response's `Call` field now references `ModerationCallResponse`.

## Breaking changes
`ModerationCallResponse` replaces the moderation `CallResponse`; source-breaking for code referencing it. Warrants a major version bump at release.

## Test plan
- `dotnet build` succeeds, `dotnet format` clean.
- Tests run in CI.
