### PR TITLE
chore: add opt-in retry for rate-limited and transport-failed requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Pass `Logger` on `StreamOptions` (or `ClientBuilder.Logger(...)`) to receive str
 | `client.initialized` | INFO | Once, at `BaseClient` construction |
 | `http.request.sent` | DEBUG | Before every request is sent |
 | `http.response.received` | DEBUG | After any HTTP response, including 4xx/5xx |
-| `http.request.failed` | ERROR | Only on a transport failure (no HTTP response received) |
+| `http.request.failed` | ERROR or DEBUG | ERROR on a final transport failure (no HTTP response received); DEBUG instead, with a `{RetryAttempt}` field, on any attempt that [Retry](#retry-policy) will retry. Never emitted for a final/non-retried 429 (already covered by `http.response.received`). |
 
 .NET's `ILogger` uses PascalCase message-template placeholders (`{Method}`, `{StatusCode}`, ...). Each maps to a canonical snake_case field name used identically across all GetStream SDKs:
 
@@ -116,15 +116,36 @@ Pass `Logger` on `StreamOptions` (or `ClientBuilder.Logger(...)`) to receive str
 | | `{Body}` | `body` (redacted; only present when `LogBodies=true`) |
 | `http.request.failed` | `{Method}` | `method` |
 | | `{Path}` | `path` |
-| | `{ErrorType}` | `error.type` |
-| | `{DurationMs}` | `duration_ms` |
-| | `{Message}` | `error.message` (redacted) |
+| | `{ErrorType}` | `error.type` (transport failures only; never present on a retried 429 — see below) |
+| | `{DurationMs}` | `duration_ms` (transport failures only) |
+| | `{Message}` | `error.message` (redacted; transport failures only) |
+| | `{RetryAttempt}` | `retry.attempt` (1-indexed; present only when this attempt will be retried) |
 
-`error.type` is one of `connection_reset`, `timeout`, `dns_failure`, `tls_handshake_failed`, `unknown` (see `GetStreamTransportException.ErrorType`).
+`error.type` is one of `connection_reset`, `timeout`, `dns_failure`, `tls_handshake_failed`, `unknown` (see `GetStreamTransportException.ErrorType`) — a closed transport-only enum. A retried HTTP 429 has no transport error at all, so its `http.request.failed` DEBUG line carries only `{Method}`, `{Path}`, `{RetryAttempt}`: never `{ErrorType}`.
 
 **Redaction (always on, no opt-out):** query values for `api_key`/`api_secret`/`token` (case-insensitive) become `<redacted>`; top-level JSON body keys `api_secret`/`token`/`password` become `<redacted>` (shallow, key names are preserved). No header values are ever logged. `error.message` is additionally scrubbed for any `api_key=`/`api_secret=`/`token=` value appearing anywhere in the free-form transport-exception text.
 
 **Bodies are not logged by default.** Set `StreamOptions.LogBodies = true` (or `ClientBuilder.LogBodies(true)`) to opt in; body content is still key-redacted as above. Enabling it emits exactly one WARN line at construction.
+
+## Retry Policy
+
+Auto-retry is opt-in and off by default: with no `Retry` configured, the client performs exactly one attempt and errors surface unchanged.
+
+```csharp
+var client = new StreamClient(new StreamOptions
+{
+    ApiKey = "...",
+    ApiSecret = "...",
+    Retry = new RetryConfig { Enabled = true, MaxAttempts = 3, MaxBackoff = TimeSpan.FromSeconds(30) },
+});
+```
+
+When enabled:
+- Only `GET`/`HEAD` requests are retried. Writes (`POST`/`PUT`/`PATCH`/`DELETE`) never are.
+- Only HTTP 429 (rate limit) and transport-layer failures (connection reset, timeout, DNS, TLS) are retried; any other 4xx/5xx is never retried.
+- A 429 marked `unrecoverable` by the backend is never retried.
+- `MaxAttempts` is the total attempt budget including the initial request (default `3`: 1 initial + 2 retries).
+- The delay before each retry honors a `Retry-After` response header when present, clamped to `MaxBackoff`; otherwise it's full jitter over `[0, min(MaxBackoff, 2^attempt seconds)]`.
 
 ## Release Process
 

--- a/src/Client.cs
+++ b/src/Client.cs
@@ -22,6 +22,7 @@ namespace GetStream
         private readonly Microsoft.Extensions.Logging.ILogger? _logger;
         private readonly bool _userHttpClient;
         private readonly bool _logBodies;
+        private readonly RetryConfig? _retry;
         protected string ApiKey;
         protected string ApiSecret;
         protected string BaseUrl;
@@ -60,6 +61,7 @@ namespace GetStream
             BaseUrl = opts.BaseUrl;
             _logger = opts.Logger;
             _logBodies = opts.LogBodies;
+            _retry = opts.Retry;
 
             if (opts.HttpClient != null)
             {
@@ -129,6 +131,11 @@ namespace GetStream
             }
         }
 
+        /// <summary>
+        /// CHA-2959 retry loop wrapping <see cref="SendOnceAsync{TRequest,TResponse}"/>. Retries are opt-in
+        /// via <see cref="StreamOptions.Retry"/> (disabled by default: exactly one attempt, errors surface
+        /// unchanged). See <see cref="ShouldRetry"/> / <see cref="RetryDelay"/> for the policy.
+        /// </summary>
         public async Task<StreamResponse<TResponse>> MakeRequestAsync<TRequest, TResponse>(
             string method,
             string path,
@@ -138,6 +145,98 @@ namespace GetStream
             CancellationToken cancellationToken = default)
         {
             var url = BuildUrl(path, queryParams, pathParams);
+            // Uri parses the same absolute URL BuildUrl just produced, so the path used for
+            // logging never drifts from what is actually sent on the wire.
+            var logPath = new Uri(url).AbsolutePath;
+
+            for (var attempt = 0; ; attempt++)
+            {
+                var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+                try
+                {
+                    return await SendOnceAsync<TRequest, TResponse>(method, url, requestBody, cancellationToken);
+                }
+                catch (GetStreamException ex)
+                {
+                    stopwatch.Stop();
+                    var willRetry = ShouldRetry(ex, method, attempt);
+
+                    // CHA-2957/CHA-2959: failure logging lives here (not in SendOnceAsync) because only the
+                    // loop knows whether this attempt will retry (DEBUG) or is final (ERROR). CROSS-SDK RULE:
+                    // ErrorType is a closed transport-only enum, so a retried 429 logs through a separate
+                    // template that omits the {ErrorType} placeholder entirely; a final/non-retried 429 logs
+                    // nothing here (unchanged: it was already logged via http.response.received).
+                    if (ex is GetStreamTransportException transportEx)
+                    {
+                        if (willRetry)
+                        {
+                            _logger?.LogDebug("http.request.failed {Method} {Path} {ErrorType} {DurationMs} {Message} {RetryAttempt}",
+                                method, logPath, transportEx.ErrorType, stopwatch.ElapsedMilliseconds,
+                                LogRedaction.RedactMessage(transportEx.Message), attempt + 1);
+                        }
+                        else
+                        {
+                            _logger?.LogError("http.request.failed {Method} {Path} {ErrorType} {DurationMs} {Message}",
+                                method, logPath, transportEx.ErrorType, stopwatch.ElapsedMilliseconds,
+                                LogRedaction.RedactMessage(transportEx.Message));
+                        }
+                    }
+                    else if (willRetry && ex is GetStreamRateLimitException)
+                    {
+                        _logger?.LogDebug("http.request.failed {Method} {Path} {RetryAttempt}", method, logPath, attempt + 1);
+                    }
+
+                    if (!willRetry) throw;
+
+                    await Task.Delay(RetryDelay(ex, attempt), cancellationToken);
+                }
+            }
+        }
+
+        /// <summary>CHA-2959: true when the retry policy is enabled and this failed attempt should be retried.</summary>
+        internal bool ShouldRetry(GetStreamException ex, string method, int attempt)
+        {
+            if (_retry is not { Enabled: true }) return false;
+            if (method != "GET" && method != "HEAD") return false;
+            if (attempt + 1 >= _retry.MaxAttempts) return false;
+
+            return ex switch
+            {
+                GetStreamRateLimitException rl => !rl.Unrecoverable,
+                GetStreamTransportException => true,
+                _ => false,
+            };
+        }
+
+        /// <summary>
+        /// CHA-2959: delay before the next attempt. Honors <c>Retry-After</c> (clamped to <see cref="RetryConfig.MaxBackoff"/>)
+        /// when present and positive; otherwise full jitter over <c>[0, min(MaxBackoff, 2^attempt seconds)]</c>.
+        /// Only called after <see cref="ShouldRetry"/> returned true, so <c>_retry</c> is non-null here.
+        /// </summary>
+        internal TimeSpan RetryDelay(GetStreamException ex, int attempt)
+        {
+            if (ex is GetStreamRateLimitException { RetryAfter: { } retryAfter } && retryAfter > TimeSpan.Zero)
+            {
+                return retryAfter < _retry!.MaxBackoff ? retryAfter : _retry.MaxBackoff;
+            }
+
+            // Exponent clamped to 30 so the shift never wraps (long shift counts are masked mod 64 in C#).
+            var ceilTicks = Math.Min(_retry!.MaxBackoff.Ticks, TimeSpan.TicksPerSecond << Math.Min(attempt, 30));
+            return ceilTicks <= 0 ? TimeSpan.Zero : TimeSpan.FromTicks((long)(Random.Shared.NextDouble() * ceilTicks));
+        }
+
+        /// <summary>
+        /// Builds and sends a single HTTP attempt: fresh <see cref="HttpRequestMessage"/> (a sent request
+        /// cannot be reused across retries), logs <c>http.request.sent</c>/<c>http.response.received</c>,
+        /// and throws on transport failure or non-2xx without logging <c>http.request.failed</c> itself
+        /// -- that is the retry loop's job (see <see cref="MakeRequestAsync{TRequest,TResponse}"/>).
+        /// </summary>
+        private async Task<StreamResponse<TResponse>> SendOnceAsync<TRequest, TResponse>(
+            string method,
+            string url,
+            TRequest? requestBody,
+            CancellationToken cancellationToken)
+        {
             var request = new HttpRequestMessage(new HttpMethod(method), url);
 
             // Add authentication headers
@@ -168,8 +267,6 @@ namespace GetStream
                 }
             }
 
-            // Uri parses the same absolute URL BuildUrl just produced, so path/query for
-            // logging never drift from what is actually sent on the wire.
             var uri = new Uri(url);
             var logPath = uri.AbsolutePath;
             var logQuery = LogRedaction.RedactQuery(uri.Query.TrimStart('?'));
@@ -197,12 +294,7 @@ namespace GetStream
             }
             catch (Exception ex) when (IsTransportException(ex, cancellationToken))
             {
-                stopwatch.Stop();
-                var transportException = WrapTransportException(ex, cancellationToken);
-                _logger?.LogError("http.request.failed {Method} {Path} {ErrorType} {DurationMs} {Message}",
-                    method, logPath, transportException.ErrorType, stopwatch.ElapsedMilliseconds,
-                    LogRedaction.RedactMessage(transportException.Message));
-                throw transportException;
+                throw WrapTransportException(ex, cancellationToken);
             }
             stopwatch.Stop();
 
@@ -239,6 +331,7 @@ namespace GetStream
         }
 
         // CHA-2957: near-duplicate send path, not exposed on IClient; intentionally not instrumented with structured logging.
+        // CHA-2959: for the same reason (not on IClient, no generated code calls it), intentionally excluded from the retry policy.
         public async Task<StreamResponse<TResponse>> MakeRequestAsyncDebug<TRequest, TResponse>(
             string method,
             string path,

--- a/src/ClientBuilder.cs
+++ b/src/ClientBuilder.cs
@@ -38,6 +38,7 @@ namespace GetStream
         private System.Net.Http.HttpClient? _httpClient;
         private ILogger? _logger;
         private bool _logBodies;
+        private RetryConfig? _retry;
 
         /// <summary>
         /// Set the API key
@@ -104,6 +105,9 @@ namespace GetStream
 
         /// <summary>Opt-in body logging (DEBUG events); shallow secret-key redaction still applies. Default false.</summary>
         public ClientBuilder LogBodies(bool enabled) { _logBodies = enabled; return this; }
+
+        /// <summary>Opt-in auto-retry policy (default: disabled, no retries).</summary>
+        public ClientBuilder Retry(RetryConfig retry) { _retry = retry; return this; }
 
         /// <summary>
         /// Create a client builder that loads configuration from environment variables
@@ -216,6 +220,7 @@ namespace GetStream
                 HttpClient = _httpClient,
                 Logger = _logger,
                 LogBodies = _logBodies,
+                Retry = _retry,
             };
         }
 

--- a/src/RetryConfig.cs
+++ b/src/RetryConfig.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace GetStream
+{
+    /// <summary>
+    /// Opt-in auto-retry policy. Disabled by default: the client performs exactly one attempt and surfaces errors unchanged.
+    /// When enabled, only GET/HEAD requests failing with HTTP 429 or a transport error are retried, and never when the backend marked the error unrecoverable.
+    /// </summary>
+    public class RetryConfig
+    {
+        /// <summary>Master switch. Default false.</summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>Total attempt budget including the initial request. Default 3 (1 initial + 2 retries).</summary>
+        public int MaxAttempts { get; set; } = 3;
+
+        /// <summary>Cap applied to every wait between attempts, including Retry-After hints. Default 30s.</summary>
+        public TimeSpan MaxBackoff { get; set; } = TimeSpan.FromSeconds(30);
+    }
+}

--- a/src/StreamOptions.cs
+++ b/src/StreamOptions.cs
@@ -41,5 +41,8 @@ namespace GetStream
 
         /// <summary>Opt-in body logging on the DEBUG events; known-secret keys stay redacted. Default false.</summary>
         public bool LogBodies { get; set; }
+
+        /// <summary>Opt-in auto-retry policy. Null (or Enabled=false) means no retries.</summary>
+        public RetryConfig? Retry { get; set; }
     }
 }

--- a/tests/RetryTests.cs
+++ b/tests/RetryTests.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using GetStream;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+
+namespace GetStream.Tests
+{
+    [TestFixture]
+    public class RetryTests
+    {
+        private sealed class ScriptedHandler : HttpMessageHandler
+        {
+            private readonly Queue<Func<HttpResponseMessage>> _steps;
+            public int Calls { get; private set; }
+
+            public ScriptedHandler(params Func<HttpResponseMessage>[] steps) => _steps = new Queue<Func<HttpResponseMessage>>(steps);
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            {
+                Calls++;
+                return Task.FromResult(_steps.Dequeue()());
+            }
+        }
+
+        private sealed class ThrowOnceHandler : HttpMessageHandler
+        {
+            public int Calls { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            {
+                Calls++;
+                if (Calls == 1) throw new HttpRequestException("reset");
+                return Task.FromResult(Json(HttpStatusCode.OK, "{}"));
+            }
+        }
+
+        // Captures the raw message template (via the "{OriginalFormat}" state entry) alongside the
+        // named field values, so tests can assert which placeholders a log line does/doesn't carry --
+        // not just substring-match the rendered text.
+        private sealed class RecordingLogger : ILogger
+        {
+            public readonly List<(LogLevel Level, string Template, Dictionary<string, object?> Fields)> Entries = new();
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                var template = string.Empty;
+                var fields = new Dictionary<string, object?>();
+                if (state is IEnumerable<KeyValuePair<string, object>> kvps)
+                {
+                    foreach (var kv in kvps)
+                    {
+                        if (kv.Key == "{OriginalFormat}") template = kv.Value?.ToString() ?? string.Empty;
+                        else fields[kv.Key] = kv.Value;
+                    }
+                }
+                Entries.Add((logLevel, template, fields));
+            }
+
+            public List<(LogLevel Level, string Template, Dictionary<string, object?> Fields)> Named(string ev) =>
+                Entries.Where(e => e.Template.StartsWith(ev)).ToList();
+        }
+
+        private static HttpResponseMessage Json(HttpStatusCode status, string body, string? retryAfter = null)
+        {
+            var resp = new HttpResponseMessage(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+            if (retryAfter != null) resp.Headers.TryAddWithoutValidation("Retry-After", retryAfter);
+            return resp;
+        }
+
+        private static BaseClient Client(HttpMessageHandler handler, RetryConfig? retry = null, ILogger? logger = null) =>
+            new BaseClient(new StreamOptions
+            {
+                ApiKey = "key",
+                ApiSecret = "secret-that-is-long-enough-for-hmac-sha256",
+                HttpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") },
+                Retry = retry,
+                Logger = logger,
+            });
+
+        private static RetryConfig Enabled(int maxAttempts = 3, double maxBackoffMs = 1) =>
+            new RetryConfig { Enabled = true, MaxAttempts = maxAttempts, MaxBackoff = TimeSpan.FromMilliseconds(maxBackoffMs) };
+
+        private static Task<StreamResponse<Dictionary<string, object>>> Get(BaseClient c) =>
+            c.MakeRequestAsync<object, Dictionary<string, object>>("GET", "/api/v2/app", null, null, null);
+
+        private static Task<StreamResponse<Dictionary<string, object>>> Head(BaseClient c) =>
+            c.MakeRequestAsync<object, Dictionary<string, object>>("HEAD", "/api/v2/app", null, null, null);
+
+        private static Task<StreamResponse<Dictionary<string, object>>> Post(BaseClient c) =>
+            c.MakeRequestAsync<object, Dictionary<string, object>>("POST", "/api/v2/x", null, null, null);
+
+        [Test]
+        public void DisabledByDefault_SingleAttempt()
+        {
+            var handler = new ScriptedHandler(() => Json(HttpStatusCode.TooManyRequests, "{}", "1"));
+            var client = Client(handler);
+            Assert.ThrowsAsync<GetStreamRateLimitException>(() => Get(client));
+            Assert.That(handler.Calls, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task EnabledGet_RetriesThenSucceeds()
+        {
+            var handler = new ScriptedHandler(
+                () => Json(HttpStatusCode.TooManyRequests, "{}"),
+                () => Json(HttpStatusCode.OK, "{}"));
+            var client = Client(handler, Enabled());
+            await Get(client);
+            Assert.That(handler.Calls, Is.EqualTo(2));
+        }
+
+        [Test]
+        public async Task EnabledHead_RetriesThenSucceeds()
+        {
+            var handler = new ScriptedHandler(
+                () => Json(HttpStatusCode.TooManyRequests, "{}"),
+                () => Json(HttpStatusCode.OK, "{}"));
+            var client = Client(handler, Enabled());
+            await Head(client);
+            Assert.That(handler.Calls, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void EnabledPost_NeverRetried()
+        {
+            var handler = new ScriptedHandler(() => Json(HttpStatusCode.TooManyRequests, "{}"));
+            var client = Client(handler, Enabled());
+            Assert.ThrowsAsync<GetStreamRateLimitException>(() => Post(client));
+            Assert.That(handler.Calls, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ServerError_NeverRetried()
+        {
+            var handler = new ScriptedHandler(() => Json(HttpStatusCode.InternalServerError, "{\"code\":1,\"message\":\"boom\"}"));
+            var client = Client(handler, Enabled());
+            Assert.ThrowsAsync<GetStreamApiException>(() => Get(client));
+            Assert.That(handler.Calls, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Unrecoverable429_NeverRetried()
+        {
+            var handler = new ScriptedHandler(() => Json(HttpStatusCode.TooManyRequests, "{\"code\":9,\"message\":\"nope\",\"unrecoverable\":true}"));
+            var client = Client(handler, Enabled());
+            Assert.ThrowsAsync<GetStreamRateLimitException>(() => Get(client));
+            Assert.That(handler.Calls, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task TransportError_Retried()
+        {
+            var handler = new ThrowOnceHandler();
+            var client = Client(handler, Enabled());
+            await Get(client);
+            Assert.That(handler.Calls, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Exhaustion_SurfacesLastError()
+        {
+            var handler = new ScriptedHandler(
+                () => Json(HttpStatusCode.TooManyRequests, "{}"),
+                () => Json(HttpStatusCode.TooManyRequests, "{}"),
+                () => Json(HttpStatusCode.TooManyRequests, "{}"));
+            var client = Client(handler, Enabled(maxAttempts: 3));
+            Assert.ThrowsAsync<GetStreamRateLimitException>(() => Get(client));
+            Assert.That(handler.Calls, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void RetryDelay_ClampsAndJitters()
+        {
+            var client = Client(new ScriptedHandler(), new RetryConfig { Enabled = true, MaxAttempts = 3, MaxBackoff = TimeSpan.FromSeconds(30) });
+            var rateLimited = new GetStreamRateLimitException("rl", 429, 9, new Dictionary<string, string>(), false, "{}", TimeSpan.FromSeconds(600));
+            Assert.That(client.RetryDelay(rateLimited, 0), Is.EqualTo(TimeSpan.FromSeconds(30)));
+
+            var transport = new GetStreamTransportException("timeout", "timeout");
+            for (var attempt = 0; attempt < 3; attempt++)
+            {
+                var ceil = TimeSpan.FromTicks(Math.Min(TimeSpan.FromSeconds(30).Ticks, TimeSpan.TicksPerSecond << attempt));
+                for (var i = 0; i < 50; i++)
+                {
+                    var d = client.RetryDelay(transport, attempt);
+                    Assert.That(d, Is.InRange(TimeSpan.Zero, ceil));
+                }
+            }
+        }
+
+        // -- Logging integration (CHA-2957/CHA-2959 reconciliation) --------------------------
+
+        [Test]
+        public async Task TransportRetry_DebugLogCarriesErrorTypeAndRetryAttempt()
+        {
+            var logger = new RecordingLogger();
+            var client = Client(new ThrowOnceHandler(), Enabled(), logger);
+            await Get(client);
+
+            var failed = logger.Named("http.request.failed");
+            Assert.That(failed, Has.Count.EqualTo(1));
+            var (level, template, fields) = failed[0];
+            Assert.That(level, Is.EqualTo(LogLevel.Debug));
+            Assert.That(template, Does.Contain("{ErrorType}"));
+            Assert.That(template, Does.Contain("{RetryAttempt}"));
+            Assert.That(fields["RetryAttempt"], Is.EqualTo(1));
+            Assert.That(fields["ErrorType"], Is.EqualTo("unknown"));
+        }
+
+        [Test]
+        public async Task RateLimitRetry_DebugLogCarriesRetryAttemptButNoErrorType()
+        {
+            var handler = new ScriptedHandler(
+                () => Json(HttpStatusCode.TooManyRequests, "{}"),
+                () => Json(HttpStatusCode.OK, "{}"));
+            var logger = new RecordingLogger();
+            var client = Client(handler, Enabled(), logger);
+            await Get(client);
+
+            var failed = logger.Named("http.request.failed");
+            Assert.That(failed, Has.Count.EqualTo(1));
+            var (level, template, fields) = failed[0];
+            Assert.That(level, Is.EqualTo(LogLevel.Debug));
+            Assert.That(template, Does.Not.Contain("{ErrorType}"));
+            Assert.That(template, Does.Not.Contain("rate_limited"));
+            Assert.That(fields.ContainsKey("RetryAttempt"), Is.True);
+            Assert.That(fields["RetryAttempt"], Is.EqualTo(1));
+            Assert.That(fields.ContainsKey("ErrorType"), Is.False);
+        }
+
+        [Test]
+        public void Disabled_TransportFailure_LogsSingleErrorWithAllFields()
+        {
+            var logger = new RecordingLogger();
+            var client = Client(new ThrowOnceHandler(), retry: null, logger: logger);
+            Assert.ThrowsAsync<GetStreamTransportException>(() => Get(client));
+
+            var failed = logger.Named("http.request.failed");
+            Assert.That(failed, Has.Count.EqualTo(1));
+            var (level, template, fields) = failed[0];
+            Assert.That(level, Is.EqualTo(LogLevel.Error));
+            Assert.That(template, Does.Contain("{ErrorType}"));
+            Assert.That(fields.ContainsKey("RetryAttempt"), Is.False);
+        }
+
+        [Test]
+        public void Disabled_RateLimit_LogsNoFailed()
+        {
+            var handler = new ScriptedHandler(() => Json(HttpStatusCode.TooManyRequests, "{}"));
+            var logger = new RecordingLogger();
+            var client = Client(handler, retry: null, logger: logger);
+            Assert.ThrowsAsync<GetStreamRateLimitException>(() => Get(client));
+
+            Assert.That(logger.Named("http.request.failed"), Is.Empty);
+            Assert.That(logger.Named("http.response.received"), Has.Count.EqualTo(1));
+        }
+    }
+}


### PR DESCRIPTION
## Ticket
https://linear.app/stream/issue/CHA-2959/rate-limits-and-retry

## Summary
Adds an opt-in auto-retry policy. `RetryConfig` is disabled by default (`maxAttempts=3`, `maxBackoff=30s`). When enabled, retries ONLY `GET`/`HEAD` requests that fail with HTTP 429 or a transport error, honoring `Retry-After` (clamped to `maxBackoff`) otherwise exponential backoff with full jitter. Never retries writes or 5xx; always honors the backend `unrecoverable` flag; surfaces the last attempt's error. Config surface: `StreamOptions.Retry = new RetryConfig{...}`

## Notes
- Retry attempts are observable via the existing `http.request.failed` log event with a `retry.attempt` field (transport retries carry `error.type`; 429 retries omit it, since that field is the transport-only enum).
- Titled `chore:` intentionally so the merge does not auto-publish. Publish later via the manual **Release** workflow (`workflow_dispatch`, `minor`).
