### PR TITLE
feat!: release structured logging, opt-in auto-retries, and OpenAPI regen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.0] - 2026-07-24
+
 ### Breaking Changes: OpenAPI regen (schema name-collision fixes, CHA-3559)
 
 Regenerated from chat/ after upstream schema name-collision fixes. The JSON wire contract is unchanged for all of these; the breaks are in the generated C# type surface, so consumer code fails to compile until updated.


### PR DESCRIPTION
Release PR: stamps the accumulated `[Unreleased]` changelog as **v15.0.0**; on merge the release workflow bumps the version, tags, and publishes to NuGet.

**Major bump driven by the accumulated OpenAPI regen (CHA-3559)**, not by retry: the regen changed the generated C# type surface (return types, nullability, removed dead code), so consumer code may need updates. Structured logging and opt-in retries are additive. If you'd rather split the regen out or treat it differently, say so before merging.