### PR TITLE
feat: name the HTTP status when the error body is not JSON

### DIFF
--- a/src/Client.cs
+++ b/src/Client.cs
@@ -737,7 +737,7 @@ namespace GetStream
             else
             {
                 // Body cannot be parsed as APIError.
-                message = "failed to parse error response";
+                message = $"failed to parse error response: unexpected server response code {statusCode}";
                 code = 0;
                 exceptionFields = new Dictionary<string, string>();
                 unrecoverable = false;

--- a/tests/ErrorHandlingTests.cs
+++ b/tests/ErrorHandlingTests.cs
@@ -263,7 +263,7 @@ namespace GetStream.Tests
                     "GET", "/anything", null, null, null));
             Assert.That(ex!.StatusCode, Is.EqualTo(500));
             Assert.That(ex.Code, Is.EqualTo(0));
-            Assert.That(ex.Message, Is.EqualTo("failed to parse error response"));
+            Assert.That(ex.Message, Is.EqualTo("failed to parse error response: unexpected server response code 500"));
             Assert.That(ex.RawResponseBody, Is.EqualTo("<html>oops</html>"));
             Assert.That(ex.ExceptionFields.Count, Is.EqualTo(0));
         }


### PR DESCRIPTION
## Ticket
https://linear.app/stream/issue/CHA-4641/generated-sdks-report-the-http-status-when-the-error-body-is-not-json

## Summary
When an error body is not JSON, the SDK reported only the parse failure and hid the HTTP status. A customer saw `failed to parse error response` for a 503 that the edge proxy returned as plain text, plus a JSON parse stack trace, and could not tell which status they got. `GetStreamApiException.Message` now appends the status: `failed to parse error response: unexpected server response code 503`. `StatusCode`, `RawResponseBody` and the parse cause do not change.

The old text is still the prefix of the new message, so prefix matching and substring matching on it both keep working.

## Verification
- `dotnet build --configuration Release`: 0 errors.
- `dotnet test --filter FullyQualifiedName~MakeRequestAsync_UnparseableBody`: pass.
- `make test`: 181 failures, all integration tests that need real credentials. The base commit gives the same 181.
